### PR TITLE
Reorganize bucket prefixes for upcoming ppeople section

### DIFF
--- a/main.py
+++ b/main.py
@@ -45,7 +45,7 @@ def fetch_description():
     if path:
         data = gcs_utils.download_description(path)
     else:
-        data = gcs_utils.download_random()
+        data = gcs_utils.download_random_movie()
 
     data = utils.format_as_html(data)
     return data, 200
@@ -53,7 +53,7 @@ def fetch_description():
 @app.route("/_get_movie_list")
 def fetch_movie_index():
     """Fetch list of current movies from Cloud Storage."""
-    data = gcs_utils.fetch_all()
+    data = gcs_utils.fetch_all_movies()
     return data, 200
     
 

--- a/src/gcs_utils.py
+++ b/src/gcs_utils.py
@@ -26,15 +26,15 @@ def download_description(path):
 	blob = bucket.blob(path)
 	return json.loads(blob.download_as_text())
 
-def download_random():
+def download_random_movie():
 	"""Download a random description from the bucket."""
-	blobs = storage_client.list_blobs(BUCKET_NAME, match_glob="**.json")
+	blobs = storage_client.list_blobs(BUCKET_NAME, match_glob="movies/**.json")
 	selected_blob = random.choice(list(blobs))
 	return json.loads(selected_blob.download_as_text())
 
-def fetch_all():
+def fetch_all_movies():
 	"""Create a mapping of unique movie names to their public urls."""
-	blobs = storage_client.list_blobs(BUCKET_NAME, match_glob="**.json")
+	blobs = storage_client.list_blobs(BUCKET_NAME, match_glob="movies/**.json")
 	# Sort by movie name
 	descriptions = sorted(blobs, key=lambda b: b.name.split("/")[-2])
 	

--- a/src/translate.py
+++ b/src/translate.py
@@ -47,7 +47,7 @@ def batch_translate_and_upload(batch_size, k=2):
 			prompt = f"{title} Movie Poster"
 			img_blob = gcs_utils.upload(
 				create_image.create_image_by_env[ENV](prompt),
-				f"{date.today().strftime('%Y-%m-%d')}/{title}/image.png",
+				f"movies/{date.today().strftime('%Y-%m-%d')}/{title}/image.png",
 				content_type="image/png"
 			)
 
@@ -59,7 +59,7 @@ def batch_translate_and_upload(batch_size, k=2):
 
 			gcs_utils.upload(
 				json.dumps(result),
-				f"{date.today().strftime('%Y-%m-%d')}/{title}/description.json"
+				f"movies/{date.today().strftime('%Y-%m-%d')}/{title}/description.json"
 			)
 
 		except exceptions.NotValidArticleException as e:


### PR DESCRIPTION
Add a new top level `movies` prefix to the bucket paths to accommodate upcoming _people_ section.

## TODO on deployment:
Move existing files in the production bucket under the new prefix.

```
# fetch list of existing files
gcloud storage ls "gs://prod_not_that_movie/**" > content.txt

# move the files
./move_files.sh content.txt
```

with the following script 
```
#!/bin/bash

# Function to move files to a new top-level folder
move_files() {
  local path=$1

  # Extract path without the bucket name
  prefix=$(echo "$path" | sed 's/gs:\/\/[^\/]*\///')

  # Move files to new top-level folder
  gsutil -m mv "${path}" "gs://prod_not_that_movie/movies/${prefix}"
}

# Iterate over each path and move files
while IFS= read -r path; do
  move_files "$path"
done < "$1"
```