### PR TITLE
Pydantic article data model

### DIFF
--- a/jobs/generate_movie.py
+++ b/jobs/generate_movie.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from datetime import date
 
@@ -11,6 +10,7 @@ from jobs import (
 	utils,
 	document_extract,
 )
+from jobs.models import ArticleData
 
 
 logger = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ create_image = env_config.create_image_[ENV]
 
 BASE_URL = "https://en.wikipedia.org/api/rest_v1/page/html"
 
-async def batch_translate_and_upload(batch_size, k=2):
+async def batch_translate_and_upload(batch_size: int, k: int = 2) -> None:
 	"""Translate a random sample of titles and store results to
 	Cloud Storage bucket.
 	Args:
@@ -48,43 +48,56 @@ async def batch_translate_and_upload(batch_size, k=2):
 			f"movies/{date.today().strftime('%Y-%m-%d')}/{title}/image.png",
 			content_type="image/png"
 		)
+		
+		# Create an ArticleData object for the translation
+		plot = document_extract.get_plot(soup)
+		article_data = ArticleData(
+			title=title,
+			content={
+				"plot": plot,
+				"cast": document_extract.get_cast(soup)
+			},
+			infobox=document_extract.get_movie_infobox(soup),
+			metadata={
+				"original_title": title,
+				"url_title": url_title
+			},
+			img={
+				"prompt": prompt,
+				"url": img_blob.public_url
+			}
+		)
 
-		# Generate a translation
-		sections_to_translate = {
-			"title": title,
-			"plot": document_extract.get_plot(soup),
-			"cast": document_extract.get_cast(soup),
-			"infobox": utils.dict_to_newline_string(document_extract.get_movie_infobox(soup))
-		}
-		result = await generate_translation(sections_to_translate, k)
+		result = await generate_translation(article_data, k)
 
-		# Add the original titles
-		result["metadata"].update({
-			"original_title": title,
-			"url_title": url_title
-		})
-
-		# Add a (public) link to the related image
-		result["img"] = img_blob.public_url
+		logger.debug("Original plot:\n%s", plot)
+		logger.debug("Translated plot:\n%s", result.content["plot"])
 
 		gcs_utils.upload(
-			json.dumps(result),
+			result.model_dump_json(),
 			f"movies/{date.today().strftime('%Y-%m-%d')}/{title}/description.json"
 		)
 
-async def generate_translation(sections_to_translate, k, target_language="en"):
-	"""Translate a single Wikipedia movie article.
+async def generate_translation(article_data: ArticleData, k: int, target_language: str = "en") -> ArticleData:
+	"""Translate a Wikipedia movie article.
 	Args:
-		sections_to_translate (dict): A mapping of sections fron the original article to translate
+		article_data (ArticleData): The article data to translate
 		k (int): number of intermediary languages to translate to
 		target_language (str): language code for the final output language
 	Return:
-		A dict of the trasnalted section, similar to the input
+		The translated article data as an ArticleData object
 	"""
 	translated_sections = {}
 	chain = utils.generate_language_chain(k, source_language="en", target_language=target_language)
 	language_names = " => ".join([LANGUAGES[code] for code in chain])
 	logger.info("Languages to use %s", language_names)
+
+	# Gather all sections to translate in a single flat dict for easier processing
+	sections_to_translate = {
+		"title": article_data.title,
+		"infobox": utils.dict_to_newline_string(article_data.infobox),
+	}
+	sections_to_translate.update(article_data.content)
 
 	for idx, section in enumerate(sections_to_translate):
 		logger.info("Translating %s (%d of %d)", section, idx+1, len(sections_to_translate))
@@ -97,16 +110,18 @@ async def generate_translation(sections_to_translate, k, target_language="en"):
 		for previous, current in zip(chain, chain[1:]):
 			translated = await translator.translate(text, src=previous, dest=current)
 			text = translated.text
-		
+
 		text = utils.cleanup_translation(text)
 		translated_sections[section] = text
-
-	# Convert infobox back to a dict
-	translated_sections["infobox"] = utils.newline_string_to_dict(translated_sections["infobox"])
-
-	# Move translated title to a dedicated metadata section
-	translated_sections["metadata"] = {
-		"title": translated_sections.pop("title").title()
-	}
 	
-	return translated_sections
+	# Build a new ArticleData object with the translated content;
+	# parse infobox back to dict and keep non-content fields unchanged.
+	translated = ArticleData(
+		title=translated_sections["title"],
+		content={key: translated_sections[key] for key in article_data.content},
+		infobox=utils.newline_string_to_dict(translated_sections["infobox"]),
+		metadata=article_data.metadata,
+		img=article_data.img
+	)
+
+	return translated

--- a/jobs/generate_movie.py
+++ b/jobs/generate_movie.py
@@ -1,3 +1,4 @@
+from difflib import SequenceMatcher
 import logging
 from datetime import date
 
@@ -70,8 +71,22 @@ async def batch_translate_and_upload(batch_size: int, k: int = 2) -> None:
 
 		result = await generate_translation(article_data, k)
 
-		logger.debug("Original plot:\n%s", plot)
-		logger.debug("Translated plot:\n%s", result.content["plot"])
+		# Reject the result if the output does not seem English
+		if not utils.is_mostly_ascii(result.content["plot"]):
+			logger.warning("Rejected translation: output does not appear to be English.")
+			logger.info("Translated plot:\n%s", result.content["plot"])
+			continue
+
+		# Compute a similarity score between original and translated plot to
+		# have a rough estimate of how much the meaning changed during translation.
+		s1 = plot.split("\n")[0]
+		s2 = result.content["plot"].split("\n")[0]
+
+		logger.debug("Original plot preface:\n%s", s1)
+		logger.debug("Translated plot preface:\n%s", s2)
+
+		res = SequenceMatcher(None, s1, s2).ratio()
+		logger.info("Plot similarity score: %.2f", res)
 
 		gcs_utils.upload(
 			result.model_dump_json(),

--- a/jobs/generate_person.py
+++ b/jobs/generate_person.py
@@ -7,6 +7,7 @@ from jobs import (
 	env_config,
 	generate_movie,
 	gcs_utils,
+	utils,
 	ENV,
 	BASE,
 )
@@ -61,6 +62,10 @@ async def batch_translate_and_upload(batch_size: int, k: int = 2) -> None:
 
 		result = await generate_movie.generate_translation(article_data, k)
 		
+		if not utils.is_mostly_ascii(result.content["description"]):
+			logger.warning("Rejected translation: output does not appear to be English.")
+			continue
+
 		gcs_utils.upload(
 			result.model_dump_json(),
 			f"people/{date.today().strftime('%Y-%m-%d')}/{title}/description.json"

--- a/jobs/generate_person.py
+++ b/jobs/generate_person.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import random
 from datetime import date
@@ -7,18 +6,18 @@ from jobs import (
 	document_extract,
 	env_config,
 	generate_movie,
-	utils,
 	gcs_utils,
 	ENV,
 	BASE,
 )
+from jobs.models import ArticleData
 
 
 logger = logging.getLogger(__name__)
 create_image = env_config.create_image_[ENV]
 
 
-async def batch_translate_and_upload(batch_size, k=2):
+async def batch_translate_and_upload(batch_size: int, k: int = 2) -> None:
 	"""Translate a random sample of titles for person articles and store results to
 	Cloud Storage bucket.
 	Args:
@@ -44,28 +43,30 @@ async def batch_translate_and_upload(batch_size, k=2):
 			content_type="image/png"
 		)
 
-		# Generate a translation
-		sections_to_translate = {
-			"title": title,
-			"description": document_extract.get_description(soup),
-			"infobox": utils.dict_to_newline_string(document_extract.get_person_infobox(soup))
-		}
-		result = await generate_movie.generate_translation(sections_to_translate, k)
+		article_data = ArticleData(
+			title=title,
+			content={
+				"description": document_extract.get_description(soup),
+			},
+			infobox=document_extract.get_person_infobox(soup),
+			metadata={
+				"original_title": title,
+				"url_title": url_title
+			},
+			img={
+				"prompt": prompt,
+				"url": img_blob.public_url
+			}
+		)
+
+		result = await generate_movie.generate_translation(article_data, k)
 		
-		result["img"] = img_blob.public_url
-		result["img_prompt"] = prompt
-
-		result["metadata"].update({
-			"original_title": title,
-			"url_title": url_title
-		})
-
 		gcs_utils.upload(
-			json.dumps(result),
+			result.model_dump_json(),
 			f"people/{date.today().strftime('%Y-%m-%d')}/{title}/description.json"
 		)
 
-def get_people_list():
+def get_people_list() -> list[str]:
 	"""Get a list of people from people.txt."""
 	with open(BASE / "data" / "people.txt") as f:
 		people = [
@@ -76,7 +77,7 @@ def get_people_list():
 
 	return people
 
-def get_person_portrait_prompt(category):
+def get_person_portrait_prompt(category: str) -> str:
 	"""Select a random prompt for a person portrait image.
 	Args:
 		category (str): the category of prompts to choose from: actor|director

--- a/jobs/main.py
+++ b/jobs/main.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import logging
 
 from jobs import (
 	generate_movie,
@@ -16,7 +17,17 @@ if __name__ == "__main__":
 						help="Number of descriptions to generate in this batch.")
 	parser.add_argument("--k", type=int, default=2,
 						help="Number of intermediary languages to translate to.")
+	parser.add_argument("--debug", action="store_true", help="Enable debug logging.")
 	args = parser.parse_args()
+
+	if args.debug:
+		logger = logging.getLogger("jobs")
+		logger.setLevel(logging.DEBUG)
+
+		# Ensure all handlers also use the same level
+		for handler in logger.handlers:
+			handler.setLevel(logging.DEBUG)
+
 
 	if args.type == "movie":
 		asyncio.run(generate_movie.batch_translate_and_upload(args.batch_size, args.k))

--- a/jobs/models.py
+++ b/jobs/models.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class ArticleData(BaseModel):
+	title: str  
+	content: dict
+	infobox: dict
+	metadata: dict
+	img: dict

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -25,7 +25,9 @@ def generate_language_chain(k, source_language, target_language):
 	Return:
 		A list of language codes to use for translation in order.
 	"""
-	languages = random.choices(list(LANGUAGES.keys()), k=k)
+	# Ensure none of the intermediary languages are the same as source or target language
+	available_languages = set(LANGUAGES.keys()) - {source_language, target_language}
+	languages = random.choices(list(available_languages), k=k)
 	languages = [source_language] + languages + [target_language]
 	return languages
 

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -69,29 +69,33 @@ def newline_string_to_dict(text):
 
 	return data
 
-def format_as_html(content):
+def format_as_html(article_data):
 	"""Convert various sections parsed from an article as html.
 	
 	Args:
-		content (dict): a dict of sections to format, e.g. plot, cast, description
+		article_data (dict): article content represented as a dict.
 	Return:
 		A dict with the same keys as the input but with the content formatted as html.
 	"""
-	# plot and cast for a movie article
-	plot = "".join([ f"<p>{p}</p>" for p in content.get("plot", "").split("\n\n") if p ])
-	cast_items = [ f"<li>{p}</li>" for p in content.get("cast", "").split("\n") if p ]
+	## Movie article:
+	# Wrap plot paragraphs in <p> tags
+	plot = "".join([ f"<p>{p}</p>" for p in article_data["content"].get("plot", "").split("\n\n") if p ])
+
+	# Wrap cast items in <li> tags
+	cast_items = [ f"<li>{p}</li>" for p in article_data["content"].get("cast", "").split("\n") if p ]
 	cast = "<ul>" + "".join(cast_items) + "</ul>"
 
-	# description for a person article
-	description = "".join([ f"<p>{p}</p>" for p in content.get("description", "").split("\n\n") if p ])
+	## Person article:
+	# Wrap description  paragraphs in <p> tags
+	description = "".join([ f"<p>{p}</p>" for p in article_data["content"].get("description", "").split("\n\n") if p ])
 
-	content.update({
+	article_data["content"].update({
 		"plot": plot,
 		"cast": cast,
 		"description": description
 	})
 
-	return content
+	return article_data
 
 def cleanup_source_text(text, replace_newlines=True):
 	"""Cleanup various whitespace and meta tokens from parsed html
@@ -173,3 +177,29 @@ def is_mostly_ascii(text, threshold=0.9):
 	"""Check if the text is mostly ascii characters."""
 	ascii_count = sum(1 for c in text if 32 <= ord(c) <= 126)
 	return ascii_count / len(text) > threshold
+
+def convert_article_data_schema(article_data):
+	"""
+	Convert old movie data format (dict) to new schema format.
+
+	Can be removed once all old format GCS data files have expired.
+	"""
+
+	# Do nothing if already in new format
+	if "content" in article_data:
+		return article_data
+
+	return {
+		"title": article_data.get("metadata", {}).get("title"),
+		"content": {
+			"plot": article_data.get("plot", ""),
+			"cast": article_data.get("cast", ""),
+			"description": article_data.get("description", "")
+		},
+		"infobox": article_data.get("infobox", {}),
+		"metadata": article_data.get("metadata", {}),
+		"img": {
+			"prompt": "",
+			"url": article_data.get("img")
+		}
+	}

--- a/jobs/utils.py
+++ b/jobs/utils.py
@@ -168,3 +168,8 @@ def select_weighted_list_of_movie_names(batch_size):
 			source_titles.extend(random.sample(titles, c[file]))
 
 	return source_titles
+
+def is_mostly_ascii(text, threshold=0.9):
+	"""Check if the text is mostly ascii characters."""
+	ascii_count = sum(1 for c in text if 32 <= ord(c) <= 126)
+	return ascii_count / len(text) > threshold

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "gunicorn",
     "openai>=2.33.0",
     "pillow>=12.2.0",
+    "pydantic>=2.13.3",
 ]
 
 [dependency-groups]

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -11,6 +11,7 @@ with patch("google.cloud.storage.Client"):
         generate_movie,
         utils
     )
+    from jobs.models import ArticleData
 
 
 
@@ -91,16 +92,28 @@ async def test_translation_chain(mocker):
     mock_translate = mocker.AsyncMock(return_value=Mock(text="Translated content."))
     mocker.patch("jobs.generate_movie.translator.translate", mock_translate)
 
-    sections_to_translate = {
-        "title": "A title",
-        "plot": "Meaningful description.",
-        "cast": "Tom Skellick as Jack\nNick Hardfloor as The Hammer",
-        "infobox": "key1:value1\n\nkey2:value2"
-    }
-    await generate_movie.generate_translation(sections_to_translate, 2)
+    article_data = ArticleData(
+        title="A title",
+        content={
+            "plot": "Meaningful description.",
+            "cast": "Tom Skellick as Jack\nNick Hardfloor as The Hammer",
+        },
+        infobox={
+            "key1": "value1",
+            "key2": "value2"
+        },
+        metadata={},
+        img={}
+    )
+    await generate_movie.generate_translation(article_data, 2)
 
+    # Asserts translations calls made.
+    # Note: order matters here.
     assert mock_translate.await_args_list == [
         mocker.call("A title", src="en", dest="fr"),
+        mocker.call("Translated content.", src="fr", dest="de"),
+        mocker.call("Translated content.", src="de", dest="en"),
+        mocker.call("key1:value1\n\nkey2:value2", src="en", dest="fr"),
         mocker.call("Translated content.", src="fr", dest="de"),
         mocker.call("Translated content.", src="de", dest="en"),
         mocker.call("Meaningful description.", src="en", dest="fr"),
@@ -108,36 +121,65 @@ async def test_translation_chain(mocker):
         mocker.call("Translated content.", src="de", dest="en"),
         mocker.call("Tom Skellick as Jack\nNick Hardfloor as The Hammer", src="en", dest="fr"),
         mocker.call("Translated content.", src="fr", dest="de"),
-        mocker.call("Translated content.", src="de", dest="en"),
-        mocker.call("key1:value1\n\nkey2:value2", src="en", dest="fr"),
-        mocker.call("Translated content.", src="fr", dest="de"),
         mocker.call("Translated content.", src="de", dest="en")
     ]
 
 @pytest.mark.asyncio
-async def test_generated_schema(mocker):
-    """Validate high level schema of the translated description."""
-    mock_translate = mocker.AsyncMock(return_value=Mock(text="Translated content."))
+async def test_translation_result(mocker):
+    """Validate translation result.
+    Non-content fields should not be modified.
+    """
+
+    def translate_side_effect(text, src=None, dest=None):
+        # Custom side effect to return different translations based on input text.
+        # If the text looks like the infobox (contains known keys), return a string that
+        # can be parsed back to a dict. This prevents the newline_string_to_dict helper
+        # from converting the mock translation to an empty dict.
+        if ("key1" in text and "key2" in text):
+            return Mock(text="translated_key1:Translated content.\n\ntranslated_key2:Translated content.")
+        return Mock(text="Translated content.")
+
+    mock_translate = mocker.AsyncMock(side_effect=translate_side_effect)
     mocker.patch("jobs.generate_movie.translator.translate", mock_translate)
 
-    sections_to_translate = {
-        "title": "A title",
-        "plot": "Meaningful description.",
-        "cast": "Tom Skellick as Jack\nNick Hardfloor as The Hammer",
-        "infobox": "key1:value1\n\nkey2:value2"
-    }
-    translation = await generate_movie.generate_translation(sections_to_translate, 2)
-
-    expected_schema = schema({
-        "plot": str,
-        "cast": str,
-        "infobox": dict,
-        "metadata": {
-            "title": str
+    article_data = ArticleData(
+        title="A title",
+        content={
+            "plot": "Meaningful description.",
+            "cast": "Tom Skellick as Jack\nNick Hardfloor as The Hammer",
+        },
+        infobox={
+            "key1": "value1",
+            "key2": "value2"
+        },
+        metadata={
+            "key": "value"
+        },
+        img={
+            "url": "https://example.com/image.png"
         }
-    })
+    )
 
-    assert expected_schema.is_valid(translation)
+    translation = await generate_movie.generate_translation(article_data, 2)
+
+    assert translation == ArticleData(
+        title="Translated content.",
+        content={
+            "plot": "Translated content.",
+            "cast": "Translated content."
+        },
+        infobox={
+            "translated_key1": "Translated content.",
+            "translated_key2": "Translated content."
+        },
+        metadata={
+            "key": "value"
+        },
+        img={
+            "url": "https://example.com/image.png"
+        }
+    )
+
 
 @pytest.mark.parametrize(
     "url_title,expected",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,18 +8,44 @@ from jobs import (
 
 def test_format_as_html():
     """Test html formatting of parsed content."""
-    description = {
-        "plot": "one\n\ntwo\n\nthree\n\nfour.",
-        "cast": "James as lion\nJohn as submarine"
+    article_data = {
+        "title": "A title",
+        "content": {
+            "plot": "one\n\ntwo\n\nthree\n\nfour.",
+            "cast": "James as lion\nJohn as submarine"
+        },
+        "infobox": {
+            "key1": "value1",
+            "key2": "value2"
+        },
+        "metadata": {
+            "key": "value"
+        },
+        "img": {
+            "url": "https://example.com/image.png"
+        }
     }
 
-    formatted = {
-        "plot": "<p>one</p><p>two</p><p>three</p><p>four.</p>",
-        "cast": "<ul><li>James as lion</li><li>John as submarine</li></ul>",
-        "description": ""
+    expected = {
+        "title": "A title",
+        "content": {
+            "plot": "<p>one</p><p>two</p><p>three</p><p>four.</p>",
+            "cast": "<ul><li>James as lion</li><li>John as submarine</li></ul>",
+            "description": ""
+        },
+        "infobox": {
+            "key1": "value1",
+            "key2": "value2"
+        },
+        "metadata": {
+            "key": "value"
+        },
+        "img": {
+            "url": "https://example.com/image.png"
+        }
     }
 
-    assert utils.format_as_html(description) == formatted
+    assert utils.format_as_html(article_data) == expected
 
 @pytest.mark.parametrize(
     "test_string,expected",
@@ -29,7 +55,7 @@ def test_format_as_html():
         ("one two.three", "one two.three")
     ])
 def test_cleanup_translation(test_string, expected):
-    """Test translation generated common tokens."""
+    """Test cleanup of common erroneous characters introduced by translation."""
     assert utils.cleanup_translation(test_string) == expected
 
     # Longer sample
@@ -45,3 +71,37 @@ def test_cleanup_translation(test_string, expected):
     life from getting married to reading. The hit and violent pull the room.
     """
     assert utils.cleanup_translation(s) == expected
+
+def test_convert_article_data_schema():
+    """Test article data schema conversion from old to new format."""
+
+    # Old to new
+    old_data = {
+        "plot": "A hero saves the world.",
+        "cast": "Actor A, Actor B",
+        "description": "An epic adventure.",
+        "infobox": {"year": 2020, "genre": "Action"},
+        "metadata": {"title": "Epic Movie", "id": 123},
+        "img": "http://example.com/image.jpg"
+    }
+    expected = {
+        "title": "Epic Movie",
+        "content": {
+            "plot": "A hero saves the world.",
+            "cast": "Actor A, Actor B",
+            "description": "An epic adventure."
+        },
+        "infobox": {"year": 2020, "genre": "Action"},
+        "metadata": {"title": "Epic Movie", "id": 123},
+        "img": {
+            "prompt": "",
+            "url": "http://example.com/image.jpg"
+        }
+    }
+    result = utils.convert_article_data_schema(old_data)
+    assert result == expected
+
+    # Should have no effect on already new format
+    new_data = expected
+    result = utils.convert_article_data_schema(new_data)
+    assert result == expected

--- a/uv.lock
+++ b/uv.lock
@@ -700,6 +700,7 @@ dependencies = [
     { name = "gunicorn" },
     { name = "openai" },
     { name = "pillow" },
+    { name = "pydantic" },
 ]
 
 [package.dev-dependencies]
@@ -720,6 +721,7 @@ requires-dist = [
     { name = "gunicorn" },
     { name = "openai", specifier = ">=2.33.0" },
     { name = "pillow", specifier = ">=12.2.0" },
+    { name = "pydantic", specifier = ">=2.13.3" },
 ]
 
 [package.metadata.requires-dev]

--- a/webserver/static/js/set_content.js
+++ b/webserver/static/js/set_content.js
@@ -22,7 +22,6 @@ $(function() {
 function setContent(path) {
     $.ajax({
         beforeSend: function(request) {
-            request.setRequestHeader("X-Button-Callback", "true");
             // Hide content and display the loader
             $(".loader").show();
             $("#movie_title").empty();
@@ -38,13 +37,13 @@ function setContent(path) {
         success: function(data) {
             // Set description content and hide loader
             $(".loader").hide();
-            $("#movie_title").html(data.metadata.title);
+            $("#movie_title").html(data.title);
             $("#original_movie_title").html(
                 `<a href="https://en.wikipedia.org/wiki/${data.metadata.url_title}">
                     (${data.metadata.original_title})</a>`
             );
-            $("#plot").html(data.plot);
-            $("#cast").html(data.cast);
+            $("#plot").html(data.content.plot);
+            $("#cast").html(data.content.cast);
             updateInfobox("#movie-info-table", data);
         },
         error: function(jqXHR, textStatus, errorThrown) {
@@ -65,14 +64,14 @@ function setContent(path) {
  * @param  {Object} data    the data to write
  */
 function updateInfobox(tableId, data) {
-    $(tableId + " img.infobox-image-ref").attr("src", data.img);
+    $(tableId + " img.infobox-image-ref").attr("src", data.img.url);
 
     // Dynamically create a table row for each infobox item
     var tableHtml = "";
-    for (const key in data.infobox) {
+    for (const key in data.content.infobox) {
         tableHtml += `<tr class="infobox-data-row">
             <th class="infobox-header">${key}</th>
-            <td class="infobox-data">${data.infobox[key]}</td>
+            <td class="infobox-data">${data.content.infobox[key]}</td>
         </tr>`
     }
     $(tableId + " tr:last").after(tableHtml);
@@ -105,7 +104,6 @@ function listMovies() {
 function setPersonContent() {
     $.ajax({
         beforeSend: function(request) {
-            request.setRequestHeader("X-Button-Callback", "true");
             $("#person_title").empty();
             $("#original_person_title").empty();
             $("#person-description").empty();
@@ -115,19 +113,19 @@ function setPersonContent() {
         dataType: "json",
         url: "/_get_person",
         success: function(data) {
-            $("#person_title").html(data.metadata.title);
+            $("#person_title").html(data.title);
             $("#original_person_title").html(
                 `<a href="https://en.wikipedia.org/wiki/${data.metadata.url_title}">
                     (${data.metadata.original_title})</a>`
             );
 
-            $("#person-description").html(data.description);
+            $("#person-description").html(data.content.description);
             $(".loader").hide();
             updateInfobox("#person-info-table", data);
 
             // update metadata table image labels
-            $(".infobox-image-ref")[1].alt = data.img_prompt + " | Image created with OpenAI";
-            $(".infobox-image-ref")[1].title = data.img_prompt + " | Image created with OpenAI";
+            $(".infobox-image-ref")[1].alt = data.img.prompt + " | Image created with OpenAI";
+            $(".infobox-image-ref")[1].title = data.img.prompt + " | Image created with OpenAI";
         },
         error: function(jqXHR, textStatus, errorThrown) {
             $("#person_title").html("<h1>Something went wrong, try again</h1>");

--- a/webserver/views.py
+++ b/webserver/views.py
@@ -30,6 +30,7 @@ def fetch_movie_description():
 	else:
 		data = gcs_utils.download_random_content(ContentType.MOVIE.name)
 
+	data = utils.convert_article_data_schema(data)
 	data = utils.format_as_html(data)
 	return data, 200
 	
@@ -43,5 +44,7 @@ def fetch_movie_index():
 def fetch_person_description():
 	"""Fetch a random preson from the bucket."""
 	data = gcs_utils.download_random_content(ContentType.PERSON.name)
+	
+	data = utils.convert_article_data_schema(data)
 	data = utils.format_as_html(data)
 	return data, 200


### PR DESCRIPTION
 * Add a Pydantic data model for article data; both parsed and translated article content
   * This updates the schema of the serialized article data in Cloud Storage!
   * Add a translation function for converting existing files to new schema on fetch
* Add similarity score to track similarity between original and translated plot content based on `difflib.SequenceMatcher`
* Drop translated content if does not appear to be English